### PR TITLE
refactor: replace modules with getModules callback in tests

### DIFF
--- a/convex/__tests__/documents.test.ts
+++ b/convex/__tests__/documents.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { api } from '../_generated/api';
 import schema from '../schema';
 
-const modules = import.meta.glob('../**/*.ts');
+const getModules = () => import.meta.glob('../**/*.ts');
 
 async function setupAuthenticatedUser(t: ReturnType<typeof convexTest>) {
   const userId = await t.run(async (ctx) => {
@@ -58,7 +58,7 @@ async function setupProjectWithDocs(t: ReturnType<typeof convexTest>, userId: st
 describe('documents', () => {
   describe('list query', () => {
     it('returns documents for project owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId } = await setupProjectWithDocs(t, userId);
 
@@ -67,7 +67,7 @@ describe('documents', () => {
     });
 
     it('returns empty for non-owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -91,7 +91,7 @@ describe('documents', () => {
 
   describe('get query', () => {
     it('returns document for owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { doc1Id } = await setupProjectWithDocs(t, userId);
 
@@ -100,7 +100,7 @@ describe('documents', () => {
     });
 
     it('returns null for non-owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const docId = await t.run(async (ctx) => {
@@ -134,7 +134,7 @@ describe('documents', () => {
 
   describe('reorder mutation', () => {
     it('reorders documents', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, doc1Id, doc2Id } = await setupProjectWithDocs(t, userId);
 
@@ -151,7 +151,7 @@ describe('documents', () => {
     });
 
     it('throws for non-owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const { projectId, docId } = await t.run(async (ctx) => {
@@ -187,7 +187,7 @@ describe('documents', () => {
 
   describe('updateProcessingStatus mutation', () => {
     it('updates status', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { doc1Id } = await setupProjectWithDocs(t, userId);
 
@@ -202,7 +202,7 @@ describe('documents', () => {
     });
 
     it('throws for non-owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const docId = await t.run(async (ctx) => {
@@ -237,7 +237,7 @@ describe('documents', () => {
 
   describe('listNeedingReview query', () => {
     it('returns documents with pending entities', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -282,7 +282,7 @@ describe('documents', () => {
     });
 
     it('returns documents with pending facts', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -338,7 +338,7 @@ describe('documents', () => {
     });
 
     it('excludes documents without pending items', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -369,7 +369,7 @@ describe('documents', () => {
     });
 
     it('excludes non-completed documents', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -411,7 +411,7 @@ describe('documents', () => {
     });
 
     it('returns empty array when not project owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {

--- a/convex/__tests__/entities/helpers.ts
+++ b/convex/__tests__/entities/helpers.ts
@@ -2,7 +2,7 @@ import { convexTest } from 'convex-test';
 import type { Id } from '../../_generated/dataModel';
 import schema from '../../schema';
 
-export const modules = import.meta.glob('../../**/*.ts');
+const getModules = () => import.meta.glob('../../**/*.ts');
 
 export type TestContext = ReturnType<typeof convexTest>;
 
@@ -14,7 +14,7 @@ export const defaultStats = () => ({
 });
 
 export function createTestContext() {
-  return convexTest(schema, modules);
+  return convexTest(schema, getModules());
 }
 
 export async function setupAuthenticatedUser(t: TestContext) {

--- a/convex/__tests__/facts.test.ts
+++ b/convex/__tests__/facts.test.ts
@@ -4,7 +4,7 @@ import { api } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import schema from '../schema';
 
-const modules = import.meta.glob('../**/*.ts');
+const getModules = () => import.meta.glob('../**/*.ts');
 
 async function setupAuthenticatedUser(t: ReturnType<typeof convexTest>) {
   const userId = await t.run(async (ctx) => {
@@ -58,7 +58,7 @@ async function setupProjectWithEntityAndDoc(t: ReturnType<typeof convexTest>, us
 describe('facts', () => {
   describe('create mutation', () => {
     it('creates fact with pending status by default', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -83,7 +83,7 @@ describe('facts', () => {
     });
 
     it('creates fact with confirmed status when specified', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -104,7 +104,7 @@ describe('facts', () => {
     });
 
     it('increments project factCount stat', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -124,7 +124,7 @@ describe('facts', () => {
     });
 
     it('works on projects without pre-existing stats', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const { projectId, documentId, entityId } = await t.run(async (ctx) => {
@@ -172,7 +172,7 @@ describe('facts', () => {
     });
 
     it('stores temporal bound when provided', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -193,7 +193,7 @@ describe('facts', () => {
     });
 
     it('throws when not authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -212,7 +212,7 @@ describe('facts', () => {
     });
 
     it('throws when not project owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const { projectId, documentId, entityId } = await t.run(async (ctx) => {
@@ -266,7 +266,7 @@ describe('facts', () => {
 
   describe('confirm mutation', () => {
     it('changes status from pending to confirmed', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -292,7 +292,7 @@ describe('facts', () => {
     });
 
     it('throws when fact not found', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -321,7 +321,7 @@ describe('facts', () => {
 
   describe('reject mutation', () => {
     it('changes status from pending to rejected', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -347,7 +347,7 @@ describe('facts', () => {
     });
 
     it('decrements project factCount when rejecting fact', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const { projectId, factId } = await t.run(async (ctx) => {
@@ -401,7 +401,7 @@ describe('facts', () => {
 
   describe('listByEntity query', () => {
     it('returns all facts for entity', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -437,7 +437,7 @@ describe('facts', () => {
     });
 
     it('filters by status when provided', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -477,7 +477,7 @@ describe('facts', () => {
     });
 
     it('returns empty array when not project owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const entityId = await t.run(async (ctx) => {
@@ -510,7 +510,7 @@ describe('facts', () => {
 
   describe('listPending query', () => {
     it('returns all pending facts for project', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -559,7 +559,7 @@ describe('facts', () => {
     });
 
     it('returns empty array when not project owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -583,7 +583,7 @@ describe('facts', () => {
 
   describe('listByDocument query', () => {
     it('returns all facts extracted from document', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
       const { projectId, documentId, entityId } = await setupProjectWithEntityAndDoc(t, userId);
 
@@ -621,7 +621,7 @@ describe('facts', () => {
 
   describe('remove mutation', () => {
     it('does NOT decrement factCount when removing rejected fact', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const { projectId, rejectedFactId } = await t.run(async (ctx) => {
@@ -685,7 +685,7 @@ describe('facts', () => {
     });
 
     it('deletes fact and decrements project stat', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const { projectId, factId } = await t.run(async (ctx) => {

--- a/convex/__tests__/lib/auth.test.ts
+++ b/convex/__tests__/lib/auth.test.ts
@@ -2,12 +2,12 @@ import { convexTest } from 'convex-test';
 import { describe, it, expect } from 'vitest';
 import schema from '../../schema';
 
-const modules = import.meta.glob('../../**/*.ts');
+const getModules = () => import.meta.glob('../../**/*.ts');
 
 describe('auth helpers', () => {
   describe('getCurrentUser', () => {
     it('returns null when not authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
 
       const user = await t.run(async (ctx) => {
         const { getCurrentUser } = await import('../../lib/auth');
@@ -18,7 +18,7 @@ describe('auth helpers', () => {
     });
 
     it('returns user when authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
 
       const userId = await t.run(async (ctx) => {
         return await ctx.db.insert('users', {
@@ -42,7 +42,7 @@ describe('auth helpers', () => {
 
   describe('requireAuth', () => {
     it('throws when not authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
 
       await expect(
         t.run(async (ctx) => {
@@ -53,7 +53,7 @@ describe('auth helpers', () => {
     });
 
     it('returns userId when authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
 
       const userId = await t.run(async (ctx) => {
         return await ctx.db.insert('users', {
@@ -76,7 +76,7 @@ describe('auth helpers', () => {
 
   describe('requireAuthUser', () => {
     it('throws when not authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
 
       await expect(
         t.run(async (ctx) => {
@@ -87,7 +87,7 @@ describe('auth helpers', () => {
     });
 
     it('returns full user object when authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
 
       const userId = await t.run(async (ctx) => {
         return await ctx.db.insert('users', {

--- a/convex/__tests__/llm/cache.test.ts
+++ b/convex/__tests__/llm/cache.test.ts
@@ -3,12 +3,12 @@ import { convexTest } from 'convex-test';
 import { internal } from '../../_generated/api';
 import schema from '../../schema';
 
-const modules = import.meta.glob('../../**/*.ts');
+const getModules = () => import.meta.glob('../../**/*.ts');
 
 describe('checkCache', () => {
   describe('cache miss', () => {
     it('returns null for new content', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const hash = await t.query(internal.llm.utils.computeHash, {
         content: 'Test content',
       });
@@ -22,7 +22,7 @@ describe('checkCache', () => {
     });
 
     it('returns null for different prompt version', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const hash = await t.query(internal.llm.utils.computeHash, {
         content: 'Test content',
       });
@@ -47,7 +47,7 @@ describe('checkCache', () => {
     });
 
     it('returns null for expired cache entry', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const hash = await t.query(internal.llm.utils.computeHash, {
         content: 'Expired content',
       });
@@ -74,7 +74,7 @@ describe('checkCache', () => {
 
   describe('cache hit', () => {
     it('returns stored response for existing hash', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const hash = await t.query(internal.llm.utils.computeHash, {
         content: 'Test content',
       });
@@ -108,7 +108,7 @@ describe('checkCache', () => {
 
 describe('saveToCache', () => {
   it('stores response with correct hash and expiresAt', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const hash = await t.query(internal.llm.utils.computeHash, {
       content: 'Test content',
     });
@@ -144,7 +144,7 @@ describe('saveToCache', () => {
 
 describe('invalidateCache', () => {
   it('removes all entries for prompt version', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const hash = await t.query(internal.llm.utils.computeHash, {
       content: 'Test content',
     });
@@ -181,7 +181,7 @@ describe('invalidateCache', () => {
   });
 
   it('removes specific entry by hash', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const hash = await t.query(internal.llm.utils.computeHash, {
       content: 'Test content',
     });

--- a/convex/__tests__/llm/extract.test.ts
+++ b/convex/__tests__/llm/extract.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { internal } from '../../_generated/api';
 import schema from '../../schema';
 
-const modules = import.meta.glob('../../**/*.ts');
+const getModules = () => import.meta.glob('../../**/*.ts');
 
 async function setupProjectWithDocument(t: ReturnType<typeof convexTest>) {
   return await t.run(async (ctx) => {
@@ -39,7 +39,7 @@ async function setupProjectWithDocument(t: ReturnType<typeof convexTest>) {
 
 describe('processExtractionResult', () => {
   it('creates entities with pending status from extraction result', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -87,7 +87,7 @@ describe('processExtractionResult', () => {
   });
 
   it('creates facts with pending status from extraction result', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -139,7 +139,7 @@ describe('processExtractionResult', () => {
   });
 
   it('stores relationships as facts with relationshipType as predicate', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -178,7 +178,7 @@ describe('processExtractionResult', () => {
   });
 
   it('reuses existing entity when name matches', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     await t.run(async (ctx) => {
@@ -234,7 +234,7 @@ describe('processExtractionResult', () => {
   });
 
   it('updates document processingStatus to completed', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -254,7 +254,7 @@ describe('processExtractionResult', () => {
   });
 
   it('updates project stats with new entity and fact counts', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -286,7 +286,7 @@ describe('processExtractionResult', () => {
   });
 
   it('handles empty extraction result gracefully', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -305,7 +305,7 @@ describe('processExtractionResult', () => {
   });
 
   it('skips facts for entities that do not exist', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -348,7 +348,7 @@ describe('processExtractionResult', () => {
   });
 
   it('persists evidencePosition for facts when provided', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -384,7 +384,7 @@ describe('processExtractionResult', () => {
   });
 
   it('persists evidencePosition for relationships when provided', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -421,7 +421,7 @@ describe('processExtractionResult', () => {
   });
 
   it('handles facts without evidencePosition', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {
@@ -456,7 +456,7 @@ describe('processExtractionResult', () => {
   });
 
   it('handles entity with missing aliases array', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { projectId, documentId } = await setupProjectWithDocument(t);
 
     const extractionResult = {

--- a/convex/__tests__/projects.test.ts
+++ b/convex/__tests__/projects.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { api } from '../_generated/api';
 import schema from '../schema';
 
-const modules = import.meta.glob('../**/*.ts');
+const getModules = () => import.meta.glob('../**/*.ts');
 
 async function setupAuthenticatedUser(t: ReturnType<typeof convexTest>) {
   const userId = await t.run(async (ctx) => {
@@ -21,7 +21,7 @@ async function setupAuthenticatedUser(t: ReturnType<typeof convexTest>) {
 describe('projects', () => {
   describe('list query', () => {
     it('returns empty array when user has no projects', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projects = await asUser.query(api.projects.list, {});
@@ -29,13 +29,13 @@ describe('projects', () => {
     });
 
     it('returns empty array when not authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const projects = await t.query(api.projects.list, {});
       expect(projects).toEqual([]);
     });
 
     it('returns only user projects, not other users', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       await t.run(async (ctx) => {
@@ -67,7 +67,7 @@ describe('projects', () => {
 
   describe('get query', () => {
     it('returns project when user is owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -87,7 +87,7 @@ describe('projects', () => {
     });
 
     it('returns null when user is not owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -109,7 +109,7 @@ describe('projects', () => {
     });
 
     it('returns null for non-existent project', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -130,7 +130,7 @@ describe('projects', () => {
 
   describe('create mutation', () => {
     it('creates project with initialized stats', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await asUser.mutation(api.projects.create, {
@@ -151,7 +151,7 @@ describe('projects', () => {
     });
 
     it('throws when not authenticated', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
 
       await expect(t.mutation(api.projects.create, { name: 'Test' })).rejects.toThrow(
         /unauthorized/i
@@ -159,7 +159,7 @@ describe('projects', () => {
     });
 
     it('creates project without description', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await asUser.mutation(api.projects.create, {
@@ -174,7 +174,7 @@ describe('projects', () => {
 
   describe('update mutation', () => {
     it('updates project name', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -196,7 +196,7 @@ describe('projects', () => {
     });
 
     it('throws when not owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -219,7 +219,7 @@ describe('projects', () => {
     });
 
     it('throws when project not found', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -241,7 +241,7 @@ describe('projects', () => {
 
   describe('remove mutation', () => {
     it('deletes project', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -260,7 +260,7 @@ describe('projects', () => {
     });
 
     it('cascades delete to documents', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const { projectId, documentId } = await t.run(async (ctx) => {
@@ -292,7 +292,7 @@ describe('projects', () => {
     });
 
     it('throws when not owner', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {
@@ -317,7 +317,7 @@ describe('projects', () => {
 
   describe('updateStats mutation', () => {
     it('updates stats partially', async () => {
-      const t = convexTest(schema, modules);
+      const t = convexTest(schema, getModules());
       const { userId, asUser } = await setupAuthenticatedUser(t);
 
       const projectId = await t.run(async (ctx) => {

--- a/convex/__tests__/seed.test.ts
+++ b/convex/__tests__/seed.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { internal } from '../_generated/api';
 import schema from '../schema';
 
-const modules = import.meta.glob('../**/*.ts');
+const getModules = () => import.meta.glob('../**/*.ts');
 
 async function setupAuthenticatedUser(t: ReturnType<typeof convexTest>) {
   const userId = await t.run(async (ctx) => {
@@ -19,7 +19,7 @@ async function setupAuthenticatedUser(t: ReturnType<typeof convexTest>) {
 
 describe('seed.seedProject internal mutation', () => {
   it('creates project with correct stats', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { userId } = await setupAuthenticatedUser(t);
 
     const result = await t.mutation(internal.seed.seedProject, { userId });
@@ -40,7 +40,7 @@ describe('seed.seedProject internal mutation', () => {
   });
 
   it('creates two documents with correct content', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { userId } = await setupAuthenticatedUser(t);
 
     const result = await t.mutation(internal.seed.seedProject, { userId });
@@ -69,7 +69,7 @@ describe('seed.seedProject internal mutation', () => {
   });
 
   it('creates entities with correct types and firstMentionedIn', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { userId } = await setupAuthenticatedUser(t);
 
     const result = await t.mutation(internal.seed.seedProject, { userId });
@@ -116,7 +116,7 @@ describe('seed.seedProject internal mutation', () => {
   });
 
   it('creates facts with correct evidencePositions', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { userId } = await setupAuthenticatedUser(t);
 
     const result = await t.mutation(internal.seed.seedProject, { userId });
@@ -143,7 +143,7 @@ describe('seed.seedProject internal mutation', () => {
   });
 
   it('returns projectId and documentIds', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { userId } = await setupAuthenticatedUser(t);
 
     const result = await t.mutation(internal.seed.seedProject, { userId });
@@ -155,7 +155,7 @@ describe('seed.seedProject internal mutation', () => {
 
 describe('seed.clearSeedData internal mutation', () => {
   it('deletes all seed data for a project', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { userId } = await setupAuthenticatedUser(t);
 
     const seedResult = await t.mutation(internal.seed.seedProject, { userId });
@@ -192,7 +192,7 @@ describe('seed.clearSeedData internal mutation', () => {
   });
 
   it('handles non-existent project gracefully', async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, getModules());
     const { userId } = await setupAuthenticatedUser(t);
 
     const fakeProjectId = await t.run(async (ctx) => {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as __tests___entities_helpers from "../__tests__/entities/helpers.js";
 import type * as auth from "../auth.js";
 import type * as chat from "../chat.js";
 import type * as documents from "../documents.js";
@@ -33,6 +34,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "__tests__/entities/helpers": typeof __tests___entities_helpers;
   auth: typeof auth;
   chat: typeof chat;
   documents: typeof documents;


### PR DESCRIPTION
Small fix to stop builds breaking