### PR TITLE
feat: Canon Browser polish and integration

### DIFF
--- a/docs/PHASE-3-browser.md
+++ b/docs/PHASE-3-browser.md
@@ -29,7 +29,7 @@ Phase 3 focuses on the Canon Browser UI, allowing users to explore, search, and 
 | 3.4 Entity Editing & Management | ✅ Complete | #18 | Inline + dedicated page editing |
 | 3.5 Timeline View | ✅ Complete | - | Events by document order |
 | 3.6 Relationship Visualization | ✅ Complete | - | D3 force-directed graph |
-| 3.7 Polish & Integration | 🔲 Pending | - | - |
+| 3.7 Polish & Integration | ✅ Complete | - | QuickStats + Vellum empty states |
 
 ### What's Implemented (from PR #16)
 
@@ -201,12 +201,12 @@ Phase 3 focuses on the Canon Browser UI, allowing users to explore, search, and 
 
 **Components:**
 
-- Vellum empty state messages
-- `QuickStats` - Entity/fact/coverage totals
+- ✅ Vellum empty state messages (enhanced across all Canon pages)
+- ✅ `QuickStats` - Entity/fact/coverage totals with entity type breakdown
 
 **Backend:**
 
-- `projects.getCanonStats` - Aggregated canon statistics
+- ✅ `projects.getCanonStats` - Aggregated canon statistics (entities, facts, documents, coverage)
 
 ---
 

--- a/src/components/QuickStats.tsx
+++ b/src/components/QuickStats.tsx
@@ -1,0 +1,124 @@
+import {
+  BookOpen,
+  FileText,
+  Sparkles,
+  User,
+  MapPin,
+  Package,
+  Lightbulb,
+  Calendar,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type EntityCounts = {
+  character: number;
+  location: number;
+  item: number;
+  concept: number;
+  event: number;
+};
+
+type QuickStatsProps = {
+  totalEntities: number;
+  totalFacts: number;
+  totalDocuments: number;
+  processedDocuments: number;
+  coverage: number;
+  entityCounts: EntityCounts;
+  className?: string;
+};
+
+const entityTypeConfig = [
+  { key: 'character' as const, icon: User, label: 'Characters', color: 'text-entity-character' },
+  { key: 'location' as const, icon: MapPin, label: 'Locations', color: 'text-entity-location' },
+  { key: 'item' as const, icon: Package, label: 'Items', color: 'text-entity-item' },
+  { key: 'concept' as const, icon: Lightbulb, label: 'Concepts', color: 'text-entity-concept' },
+  { key: 'event' as const, icon: Calendar, label: 'Events', color: 'text-entity-event' },
+];
+
+export function QuickStats({
+  totalEntities,
+  totalFacts,
+  totalDocuments,
+  processedDocuments,
+  coverage,
+  entityCounts,
+  className,
+}: QuickStatsProps) {
+  const hasContent = totalEntities > 0 || totalFacts > 0 || totalDocuments > 0;
+
+  if (!hasContent) {
+    return null;
+  }
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+        <StatItem icon={BookOpen} label="Entities" value={totalEntities} />
+        <StatItem icon={Sparkles} label="Facts" value={totalFacts} />
+        <StatItem
+          icon={FileText}
+          label="Documents"
+          value={`${processedDocuments}/${totalDocuments}`}
+        />
+        <CoverageBar coverage={coverage} />
+      </div>
+
+      {totalEntities > 0 && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {entityTypeConfig.map(({ key, icon: Icon, label, color }) => {
+            const count = entityCounts[key];
+            if (count === 0) return null;
+            return (
+              <div key={key} className="flex items-center gap-1.5">
+                <Icon className={cn('size-3.5', color)} />
+                <span className="text-muted-foreground text-xs">
+                  {count} {count === 1 ? label.slice(0, -1) : label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type StatItemProps = {
+  icon: typeof BookOpen;
+  label: string;
+  value: number | string;
+};
+
+function StatItem({ icon: Icon, label, value }: StatItemProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className="text-muted-foreground size-4" />
+      <span className="text-sm font-medium">{value}</span>
+      <span className="text-muted-foreground text-sm">{label}</span>
+    </div>
+  );
+}
+
+type CoverageBarProps = {
+  coverage: number;
+};
+
+function CoverageBar({ coverage }: CoverageBarProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="bg-muted h-2 w-20 overflow-hidden rounded-full">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-300',
+            coverage >= 100 ? 'bg-green-500'
+            : coverage >= 50 ? 'bg-primary'
+            : 'bg-amber-500'
+          )}
+          style={{ width: `${Math.min(coverage, 100)}%` }}
+        />
+      </div>
+      <span className="text-muted-foreground text-xs">{coverage}% processed</span>
+    </div>
+  );
+}

--- a/src/routes/projects_.$projectId_.canon.connections.tsx
+++ b/src/routes/projects_.$projectId_.canon.connections.tsx
@@ -94,13 +94,11 @@ function CanonConnections() {
 
       {graph.nodes.length === 0 ?
         <EmptyState
-          title={
-            entityFilter !== 'all' ? 'No relationships for this entity' : 'No relationships yet'
-          }
+          title={entityFilter !== 'all' ? 'No connections traced' : 'The web awaits its threads'}
           description={
             entityFilter !== 'all' ?
-              'This entity has no inferred connections to other entities based on current facts.'
-            : 'Relationships will appear here as facts are extracted that mention multiple entities.'
+              'This entity stands alone in the archive—for now. Connections will emerge as more facts are cataloged.'
+            : 'Relationships between entities will materialize here as Vellum weaves connections from the facts you confirm.'
           }
         />
       : <div className="bg-card h-[600px] rounded-lg border">

--- a/src/routes/projects_.$projectId_.canon.timeline.tsx
+++ b/src/routes/projects_.$projectId_.canon.timeline.tsx
@@ -153,11 +153,11 @@ function CanonTimeline() {
 
       {timelineItems.length === 0 ?
         <EmptyState
-          title={entityFilter !== 'all' ? 'No timeline entries for this entity' : 'No events yet'}
+          title={entityFilter !== 'all' ? 'No chronicle entries found' : 'The timeline awaits'}
           description={
             entityFilter !== 'all' ?
-              'This entity has no events or first appearances in your canon yet.'
-            : 'Events and entity first appearances will show here as you add documents and extract canon.'
+              'This entity has yet to make their mark on the timeline. Their story will unfold as you process more documents.'
+            : 'Events and first appearances will emerge here as Vellum catalogs your documents. The chronicle builds itself, one extraction at a time.'
           }
         />
       : <div className="relative">

--- a/src/routes/projects_.$projectId_.canon.tsx
+++ b/src/routes/projects_.$projectId_.canon.tsx
@@ -5,6 +5,7 @@ import { api } from '../../convex/_generated/api';
 import type { Id } from '../../convex/_generated/dataModel';
 import { Button } from '@/components/ui/button';
 import { LoadingState } from '@/components/LoadingState';
+import { QuickStats } from '@/components/QuickStats';
 import { cn } from '@/lib/utils';
 
 export const Route = createFileRoute('/projects_/$projectId_/canon')({
@@ -15,6 +16,9 @@ function CanonLayout() {
   const navigate = useNavigate();
   const { projectId } = Route.useParams();
   const project = useQuery(api.projects.get, { id: projectId as Id<'projects'> });
+  const canonStats = useQuery(api.projects.getCanonStats, {
+    projectId: projectId as Id<'projects'>,
+  });
 
   if (project === undefined) {
     return <LoadingState message="Loading project..." />;
@@ -64,6 +68,17 @@ function CanonLayout() {
             </NavLink>
           </nav>
         </div>
+        {canonStats && (
+          <QuickStats
+            totalEntities={canonStats.totalEntities}
+            totalFacts={canonStats.totalFacts}
+            totalDocuments={canonStats.totalDocuments}
+            processedDocuments={canonStats.processedDocuments}
+            coverage={canonStats.coverage}
+            entityCounts={canonStats.entityCounts}
+            className="mt-4"
+          />
+        )}
       </div>
       <Outlet />
     </div>


### PR DESCRIPTION
## Summary

Completes the Canon Browser feature, adding polish and integration features.

- Add `QuickStats` component displaying entity/fact/document counts with coverage bar
- Add `projects.getCanonStats` backend query for aggregated canon statistics
- Enhance empty states with consistent Vellum-style messaging across Canon pages

## Changes

| File | Change |
|------|--------|
| `convex/projects.ts` | Add `getCanonStats` query |
| `convex/__tests__/projects.test.ts` | Add 4 tests for new query |
| `src/components/QuickStats.tsx` | New stats display component |
| `src/routes/projects_.$projectId_.canon.tsx` | Integrate QuickStats |
| `src/routes/projects_.$projectId_.canon.timeline.tsx` | Vellum empty states |
| `src/routes/projects_.$projectId_.canon.connections.tsx` | Vellum empty states |