### PR TITLE
feat: add interactive tutorial tour with driver.js

### DIFF
--- a/convex/__tests__/users.test.ts
+++ b/convex/__tests__/users.test.ts
@@ -1,0 +1,109 @@
+import { convexTest } from 'convex-test';
+import { describe, it, expect } from 'vitest';
+import { api } from '../_generated/api';
+import schema from '../schema';
+
+const getModules = () => import.meta.glob('../**/*.ts');
+
+async function setupAuthenticatedUser(t: ReturnType<typeof convexTest>) {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', {
+      name: 'Test User',
+      email: 'test@example.com',
+      createdAt: Date.now(),
+    });
+  });
+
+  const asUser = t.withIdentity({ subject: userId });
+  return { userId, asUser };
+}
+
+describe('users', () => {
+  describe('viewer query', () => {
+    it('returns null when not authenticated', async () => {
+      const t = convexTest(schema, getModules());
+      const viewer = await t.query(api.users.viewer, {});
+      expect(viewer).toBeNull();
+    });
+
+    it('returns user when authenticated', async () => {
+      const t = convexTest(schema, getModules());
+      const { asUser } = await setupAuthenticatedUser(t);
+      const viewer = await asUser.query(api.users.viewer, {});
+      expect(viewer).not.toBeNull();
+      expect(viewer?.name).toBe('Test User');
+    });
+  });
+
+  describe('startTour mutation', () => {
+    it('initializes tour state for user', async () => {
+      const t = convexTest(schema, getModules());
+      const { userId, asUser } = await setupAuthenticatedUser(t);
+
+      await asUser.mutation(api.users.startTour, {});
+
+      const user = await t.run(async (ctx) => ctx.db.get(userId));
+      expect(user?.tourState).toBeDefined();
+      expect(user?.tourState?.currentStepIndex).toBe(0);
+      expect(user?.tourState?.completed).toBe(false);
+      expect(user?.tourState?.startedAt).toBeDefined();
+    });
+
+    it('throws when not authenticated', async () => {
+      const t = convexTest(schema, getModules());
+      await expect(t.mutation(api.users.startTour, {})).rejects.toThrow('Authentication required');
+    });
+  });
+
+  describe('updateTourProgress mutation', () => {
+    it('updates step index', async () => {
+      const t = convexTest(schema, getModules());
+      const { userId, asUser } = await setupAuthenticatedUser(t);
+
+      await asUser.mutation(api.users.startTour, {});
+      await asUser.mutation(api.users.updateTourProgress, { stepIndex: 3 });
+
+      const user = await t.run(async (ctx) => ctx.db.get(userId));
+      expect(user?.tourState?.currentStepIndex).toBe(3);
+      expect(user?.tourState?.completed).toBe(false);
+    });
+
+    it('initializes tour state if not present', async () => {
+      const t = convexTest(schema, getModules());
+      const { userId, asUser } = await setupAuthenticatedUser(t);
+
+      await asUser.mutation(api.users.updateTourProgress, { stepIndex: 2 });
+
+      const user = await t.run(async (ctx) => ctx.db.get(userId));
+      expect(user?.tourState?.currentStepIndex).toBe(2);
+    });
+  });
+
+  describe('completeTour mutation', () => {
+    it('marks tour as completed with timestamp', async () => {
+      const t = convexTest(schema, getModules());
+      const { userId, asUser } = await setupAuthenticatedUser(t);
+
+      await asUser.mutation(api.users.startTour, {});
+      await asUser.mutation(api.users.completeTour, {});
+
+      const user = await t.run(async (ctx) => ctx.db.get(userId));
+      expect(user?.tourState?.completed).toBe(true);
+      expect(user?.tourState?.completedAt).toBeDefined();
+    });
+  });
+
+  describe('skipTour mutation', () => {
+    it('marks tour as completed when skipped', async () => {
+      const t = convexTest(schema, getModules());
+      const { userId, asUser } = await setupAuthenticatedUser(t);
+
+      await asUser.mutation(api.users.skipTour, {});
+
+      const user = await t.run(async (ctx) => ctx.db.get(userId));
+      expect(user?.tourState?.completed).toBe(true);
+      expect(user?.tourState?.completedAt).toBeDefined();
+      expect(user?.tourState?.currentStepIndex).toBe(0);
+    });
+  });
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14,6 +14,14 @@ export default defineSchema({
     isAnonymous: v.optional(v.boolean()),
     createdAt: v.number(),
     onboardingCompleted: v.optional(v.boolean()),
+    tourState: v.optional(
+      v.object({
+        currentStepIndex: v.number(),
+        completed: v.boolean(),
+        startedAt: v.optional(v.number()),
+        completedAt: v.optional(v.number()),
+      })
+    ),
     settings: v.optional(
       v.object({
         theme: v.optional(v.string()),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,5 +1,6 @@
 import { mutation, query } from './_generated/server';
 import { getCurrentUser, requireAuthUser } from './lib/auth';
+import { v } from 'convex/values';
 
 export const viewer = query({
   args: {},
@@ -14,5 +15,70 @@ export const completeOnboarding = mutation({
     const user = await requireAuthUser(ctx);
     await ctx.db.patch(user._id, { onboardingCompleted: true });
     return user._id;
+  },
+});
+
+export const startTour = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await requireAuthUser(ctx);
+    await ctx.db.patch(user._id, {
+      tourState: {
+        currentStepIndex: 0,
+        completed: false,
+        startedAt: Date.now(),
+      },
+    });
+  },
+});
+
+export const updateTourProgress = mutation({
+  args: { stepIndex: v.number() },
+  handler: async (ctx, { stepIndex }) => {
+    const user = await requireAuthUser(ctx);
+    const currentState = user.tourState ?? {
+      currentStepIndex: 0,
+      completed: false,
+      startedAt: Date.now(),
+    };
+    await ctx.db.patch(user._id, {
+      tourState: {
+        ...currentState,
+        currentStepIndex: stepIndex,
+      },
+    });
+  },
+});
+
+export const completeTour = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await requireAuthUser(ctx);
+    const currentState = user.tourState ?? {
+      currentStepIndex: 0,
+      completed: false,
+      startedAt: Date.now(),
+    };
+    await ctx.db.patch(user._id, {
+      tourState: {
+        ...currentState,
+        completed: true,
+        completedAt: Date.now(),
+      },
+    });
+  },
+});
+
+export const skipTour = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await requireAuthUser(ctx);
+    await ctx.db.patch(user._id, {
+      tourState: {
+        currentStepIndex: 0,
+        completed: true,
+        completedAt: Date.now(),
+      },
+    });
   },
 });

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "convex": "^1.31.2",
     "d3": "^7.9.0",
     "dompurify": "^3.3.1",
+    "driver.js": "^1.4.0",
     "lucide-react": "^0.562.0",
     "marked": "^17.0.1",
     "neverthrow": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       dompurify:
         specifier: ^3.3.1
         version: 3.3.1
+      driver.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
@@ -2985,6 +2988,9 @@ packages:
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
+
+  driver.js@1.4.0:
+    resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -7633,6 +7639,8 @@ snapshots:
       domhandler: 5.0.3
 
   dotenv@17.2.3: {}
+
+  driver.js@1.4.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/components/Vellum.tsx
+++ b/src/components/Vellum.tsx
@@ -58,6 +58,7 @@ export function VellumButton({ collapsed }: VellumButtonProps) {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger
+          data-tour="vellum"
           className={cn(
             buttonVariants({ variant: 'ghost', size: 'sm' }),
             'w-full cursor-pointer',

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -1,0 +1,186 @@
+import { driver, type DriveStep, type Driver } from 'driver.js';
+import 'driver.js/dist/driver.css';
+import { useEffect, useRef } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '../../convex/_generated/api';
+
+export const TOUR_STEPS: DriveStep[] = [
+  {
+    element: '[data-tour="sidebar-nav"]',
+    popover: {
+      title: 'Navigation',
+      description:
+        'Browse your projects and navigate to different sections. Recent projects appear here for quick access.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="project-overview"]',
+    popover: {
+      title: 'Project Dashboard',
+      description:
+        "This is your project's home. See stats, recent activity, and access all project tools from here.",
+      side: 'bottom',
+      align: 'center',
+    },
+  },
+  {
+    element: '[data-tour="documents"]',
+    popover: {
+      title: 'Documents',
+      description:
+        'Add your manuscripts, notes, and worldbuilding documents here. Vellum will extract canon facts from them.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="entities"]',
+    popover: {
+      title: 'Entities',
+      description:
+        'All characters, locations, items, and concepts extracted from your documents. Review and confirm them to build your canon.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="alerts"]',
+    popover: {
+      title: 'Continuity Alerts',
+      description:
+        "When Vellum detects contradictions or timeline issues, they'll appear here. Keep your world consistent!",
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="vellum"]',
+    popover: {
+      title: 'Meet Vellum',
+      description:
+        "Your AI archive assistant. Ask questions about your world, get writing suggestions, and explore your canon. I'm always here to help!",
+      side: 'top',
+      align: 'start',
+    },
+  },
+];
+
+export type TourCallbacks = {
+  onStepChange?: (stepIndex: number) => void;
+  onComplete?: () => void;
+  onSkip?: () => void;
+};
+
+export function createTourDriver(callbacks: TourCallbacks = {}): Driver {
+  let didComplete = false;
+
+  return driver({
+    showProgress: true,
+    steps: TOUR_STEPS,
+    nextBtnText: 'Next',
+    prevBtnText: 'Back',
+    doneBtnText: 'Get Started!',
+    progressText: '{{current}} of {{total}}',
+    onHighlightStarted: (_element, _step, options) => {
+      const activeIndex = options.state.activeIndex;
+      if (activeIndex !== undefined) {
+        callbacks.onStepChange?.(activeIndex);
+      }
+    },
+    onDestroyStarted: (_element, _step, options) => {
+      const activeIndex = options.state.activeIndex ?? 0;
+      didComplete = activeIndex >= TOUR_STEPS.length - 1;
+    },
+    onDestroyed: () => {
+      if (didComplete) {
+        callbacks.onComplete?.();
+      } else {
+        callbacks.onSkip?.();
+      }
+    },
+  });
+}
+
+export function startTour(callbacks: TourCallbacks = {}): Driver {
+  const driverObj = createTourDriver(callbacks);
+  driverObj.drive();
+  return driverObj;
+}
+
+export function useTour() {
+  const user = useQuery(api.users.viewer);
+  const startTourMutation = useMutation(api.users.startTour);
+  const updateProgress = useMutation(api.users.updateTourProgress);
+  const completeTourMutation = useMutation(api.users.completeTour);
+  const skipTourMutation = useMutation(api.users.skipTour);
+
+  const driverRef = useRef<Driver | null>(null);
+  const hasStartedRef = useRef(false);
+  const callbacksRef = useRef({
+    startTour: startTourMutation,
+    updateProgress,
+    completeTour: completeTourMutation,
+    skipTour: skipTourMutation,
+  });
+  callbacksRef.current = {
+    startTour: startTourMutation,
+    updateProgress,
+    completeTour: completeTourMutation,
+    skipTour: skipTourMutation,
+  };
+
+  const userId = user?._id;
+  const shouldStartTour =
+    user !== undefined &&
+    user !== null &&
+    (!user.tourState || (!user.tourState.completed && user.tourState.currentStepIndex === 0));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!userId) return;
+    if (hasStartedRef.current) return;
+    if (!shouldStartTour) return;
+
+    hasStartedRef.current = true;
+
+    const timer = window.setTimeout(() => {
+      void callbacksRef.current.startTour();
+
+      if (driverRef.current?.isActive()) return;
+
+      driverRef.current = createTourDriver({
+        onStepChange: (stepIndex) => {
+          void callbacksRef.current.updateProgress({ stepIndex });
+        },
+        onComplete: () => {
+          void callbacksRef.current.completeTour();
+        },
+        onSkip: () => {
+          void callbacksRef.current.skipTour();
+        },
+      });
+
+      driverRef.current.drive();
+    }, 500);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [userId, shouldStartTour]);
+
+  useEffect(() => {
+    return () => {
+      if (driverRef.current?.isActive()) {
+        driverRef.current.destroy();
+      }
+      driverRef.current = null;
+    };
+  }, []);
+
+  return {
+    isActive: driverRef.current?.isActive() ?? false,
+    destroy: () => driverRef.current?.destroy(),
+  };
+}

--- a/src/routes/projects_.$projectId.tsx
+++ b/src/routes/projects_.$projectId.tsx
@@ -21,6 +21,7 @@ import {
 import { ProjectForm } from '@/components/ProjectForm';
 import { LoadingState } from '@/components/LoadingState';
 import { ExportButton } from '@/components/ExportButton';
+import { useTour } from '@/lib/tour';
 import { cn } from '@/lib/utils';
 
 export const Route = createFileRoute('/projects_/$projectId')({
@@ -32,16 +33,19 @@ function ProjectDashboard() {
   const { projectId } = Route.useParams();
   const project = useQuery(api.projects.get, { id: projectId as Id<'projects'> });
   const documents = useQuery(api.documents.list, { projectId: projectId as Id<'projects'> });
+  const user = useQuery(api.users.viewer);
   const deleteProject = useMutation(api.projects.remove);
 
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
+  useTour();
+
   useEffect(() => {
-    if (project) {
-      addRecentProject(projectId, project.name);
+    if (project && user?._id) {
+      addRecentProject(projectId, project.name, user._id);
     }
-  }, [project, projectId]);
+  }, [project, projectId, user?._id]);
 
   if (project === undefined) {
     return <LoadingState message="Loading project..." />;
@@ -85,7 +89,7 @@ function ProjectDashboard() {
   }
 
   return (
-    <div className="container mx-auto p-6">
+    <div className="container mx-auto p-6" data-tour="project-overview">
       <div className="mb-6 flex items-start justify-between">
         <div>
           <Button

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
+@import 'driver.js/dist/driver.css';
 @import '@fontsource-variable/dm-sans';
 @import '@fontsource-variable/aleo';
 @import '@fontsource/ia-writer-mono';


### PR DESCRIPTION
## Summary

- Add 6-step interactive tutorial tour using driver.js 1.4.0
- User-scoped recent projects (localStorage keyed by userId, auto-cleans deleted projects)
- Tour state persisted in Convex backend with start/update/complete/skip mutations

## Changes

### Tour Implementation
- `src/lib/tour.ts` - Tour configuration with `createTourDriver()` and `useTour()` hook
- Tour steps: Welcome → Sidebar → Documents → Entities → Alerts → Vellum
- Fixed flash bug with stable `useEffect` dependencies
- Fixed "Get Started" button using `onDestroyed` callback with completion flag

### Backend
- `convex/schema.ts` - Added `tourState` field to users table
- `convex/users.ts` - 4 new mutations: `startTour`, `updateTourProgress`, `completeTour`, `skipTour`
- `convex/__tests__/users.test.ts` - 8 tests for tour mutations

### Recent Projects Fix
- Changed localStorage key from global to user-scoped: `realm-sync:recent-projects:${userId}`
- Added `removeRecentProject` export for cleanup
- Auto-validates against actual projects list (removes deleted projects)