### PR TITLE
fix: reset stale monthly usage counters in limits and cron

### DIFF
--- a/convex/__tests__/usage.test.ts
+++ b/convex/__tests__/usage.test.ts
@@ -1,0 +1,133 @@
+import { convexTest } from 'convex-test';
+import { describe, it, expect } from 'vitest';
+import { internal } from '../_generated/api';
+import schema from '../schema';
+import { MONTHLY_RESET_INTERVAL_MS } from '../lib/limits';
+
+const getModules = () => import.meta.glob('../**/*.ts');
+
+describe('usage', () => {
+  it('treats stale extraction usage as reset during limit checks', async () => {
+    const t = convexTest(schema, getModules());
+
+    const userId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', {
+        name: 'Stale Usage',
+        email: 'stale-usage@example.com',
+        createdAt: Date.now(),
+        usage: {
+          llmExtractionsThisMonth: 20,
+          chatMessagesThisMonth: 10,
+          usageResetAt: Date.now() - MONTHLY_RESET_INTERVAL_MS - 1000,
+        },
+      });
+    });
+
+    const result = await t.query(internal.usage.checkExtractionLimit, { userId });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.current).toBe(0);
+    }
+  });
+
+  it('resets stale extraction usage before incrementing', async () => {
+    const t = convexTest(schema, getModules());
+
+    const staleResetAt = Date.now() - MONTHLY_RESET_INTERVAL_MS - 1000;
+    const userId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', {
+        name: 'Increment User',
+        email: 'increment-usage@example.com',
+        createdAt: Date.now(),
+        usage: {
+          llmExtractionsThisMonth: 20,
+          chatMessagesThisMonth: 12,
+          usageResetAt: staleResetAt,
+        },
+      });
+    });
+
+    await t.mutation(internal.usage.incrementExtractionUsage, { userId });
+
+    const user = await t.run(async (ctx) => ctx.db.get(userId));
+    expect(user?.usage?.llmExtractionsThisMonth).toBe(1);
+    expect(user?.usage?.chatMessagesThisMonth).toBe(0);
+    expect((user?.usage?.usageResetAt ?? 0) > staleResetAt).toBe(true);
+  });
+
+  it('treats stale chat usage as reset during chat limit checks', async () => {
+    const t = convexTest(schema, getModules());
+
+    const userId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', {
+        name: 'Chat Stale',
+        email: 'chat-stale@example.com',
+        createdAt: Date.now(),
+        usage: {
+          llmExtractionsThisMonth: 5,
+          chatMessagesThisMonth: 50,
+          usageResetAt: Date.now() - MONTHLY_RESET_INTERVAL_MS - 1000,
+        },
+      });
+    });
+
+    const result = await t.query(internal.usage.checkChatLimit, { userId });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.current).toBe(0);
+    }
+  });
+
+  it('cron reset mutation resets only stale persisted usage counters', async () => {
+    const t = convexTest(schema, getModules());
+    const staleResetAt = Date.now() - MONTHLY_RESET_INTERVAL_MS - 1000;
+
+    const staleUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', {
+        name: 'Stale',
+        email: 'stale@example.com',
+        createdAt: Date.now(),
+        usage: {
+          llmExtractionsThisMonth: 12,
+          chatMessagesThisMonth: 15,
+          usageResetAt: staleResetAt,
+        },
+      });
+    });
+
+    const freshUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', {
+        name: 'Fresh',
+        email: 'fresh@example.com',
+        createdAt: Date.now(),
+        usage: {
+          llmExtractionsThisMonth: 3,
+          chatMessagesThisMonth: 4,
+          usageResetAt: Date.now(),
+        },
+      });
+    });
+
+    const noUsageUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', {
+        name: 'No Usage',
+        email: 'no-usage@example.com',
+        createdAt: Date.now(),
+      });
+    });
+
+    const result = await t.mutation(internal.usage.resetStaleUsageCounters, {});
+    expect(result.resetCount).toBe(1);
+
+    const staleUser = await t.run(async (ctx) => ctx.db.get(staleUserId));
+    expect(staleUser?.usage?.llmExtractionsThisMonth).toBe(0);
+    expect(staleUser?.usage?.chatMessagesThisMonth).toBe(0);
+
+    const freshUser = await t.run(async (ctx) => ctx.db.get(freshUserId));
+    expect(freshUser?.usage?.llmExtractionsThisMonth).toBe(3);
+    expect(freshUser?.usage?.chatMessagesThisMonth).toBe(4);
+
+    const noUsageUser = await t.run(async (ctx) => ctx.db.get(noUsageUserId));
+    expect(noUsageUser?.usage).toBeUndefined();
+  });
+});

--- a/convex/__tests__/usage.test.ts
+++ b/convex/__tests__/usage.test.ts
@@ -25,7 +25,7 @@ describe('usage', () => {
 
     const result = await t.query(internal.usage.checkExtractionLimit, { userId });
     expect(result.allowed).toBe(true);
-    if (result.allowed) {
+    if (result.allowed && 'current' in result) {
       expect(result.current).toBe(0);
     }
   });
@@ -73,7 +73,7 @@ describe('usage', () => {
 
     const result = await t.query(internal.usage.checkChatLimit, { userId });
     expect(result.allowed).toBe(true);
-    if (result.allowed) {
+    if (result.allowed && 'current' in result) {
       expect(result.current).toBe(0);
     }
   });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -15,6 +15,12 @@ crons.hourly(
   internal.cleanup.cleanupExpiredChatStreams
 );
 
+crons.daily(
+  'reset stale usage counters',
+  { hourUTC: 2, minuteUTC: 30 },
+  internal.usage.resetStaleUsageCounters
+);
+
 crons.daily('reset demo account', { hourUTC: 8, minuteUTC: 0 }, internal.seed.resetDemoAccount);
 
 export default crons;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -18,7 +18,8 @@ crons.hourly(
 crons.daily(
   'reset stale usage counters',
   { hourUTC: 2, minuteUTC: 30 },
-  internal.usage.resetStaleUsageCounters
+  internal.usage.resetStaleUsageCounters,
+  {}
 );
 
 crons.daily('reset demo account', { hourUTC: 8, minuteUTC: 0 }, internal.seed.resetDemoAccount);

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -1,6 +1,6 @@
 import { internalQuery, internalMutation } from './_generated/server';
 import { v } from 'convex/values';
-import { checkUsageLimit } from './lib/subscription';
+import { checkUsageLimit, shouldResetUsage } from './lib/subscription';
 
 export const checkExtractionLimit = internalQuery({
   args: { userId: v.id('users') },
@@ -8,7 +8,18 @@ export const checkExtractionLimit = internalQuery({
     const user = await ctx.db.get(userId);
     if (!user) return { allowed: false, reason: 'user_not_found' };
 
-    const result = checkUsageLimit(user, 'llmExtractionsPerMonth');
+    const userForLimit =
+      shouldResetUsage(user) ?
+        {
+          ...user,
+          usage: {
+            llmExtractionsThisMonth: 0,
+            chatMessagesThisMonth: 0,
+            usageResetAt: Date.now(),
+          },
+        }
+      : user;
+    const result = checkUsageLimit(userForLimit, 'llmExtractionsPerMonth');
     return result;
   },
 });
@@ -19,11 +30,15 @@ export const incrementExtractionUsage = internalMutation({
     const user = await ctx.db.get(userId);
     if (!user) return;
 
-    const currentUsage = user.usage ?? {
-      llmExtractionsThisMonth: 0,
-      chatMessagesThisMonth: 0,
-      usageResetAt: Date.now(),
-    };
+    const now = Date.now();
+    const currentUsage =
+      !user.usage || shouldResetUsage(user) ?
+        {
+          llmExtractionsThisMonth: 0,
+          chatMessagesThisMonth: 0,
+          usageResetAt: now,
+        }
+      : user.usage;
 
     await ctx.db.patch(userId, {
       usage: {
@@ -40,7 +55,18 @@ export const checkChatLimit = internalQuery({
     const user = await ctx.db.get(userId);
     if (!user) return { allowed: false, reason: 'user_not_found' };
 
-    const result = checkUsageLimit(user, 'chatMessagesPerMonth');
+    const userForLimit =
+      shouldResetUsage(user) ?
+        {
+          ...user,
+          usage: {
+            llmExtractionsThisMonth: 0,
+            chatMessagesThisMonth: 0,
+            usageResetAt: Date.now(),
+          },
+        }
+      : user;
+    const result = checkUsageLimit(userForLimit, 'chatMessagesPerMonth');
     return result;
   },
 });
@@ -51,11 +77,15 @@ export const incrementChatUsage = internalMutation({
     const user = await ctx.db.get(userId);
     if (!user) return;
 
-    const currentUsage = user.usage ?? {
-      llmExtractionsThisMonth: 0,
-      chatMessagesThisMonth: 0,
-      usageResetAt: Date.now(),
-    };
+    const now = Date.now();
+    const currentUsage =
+      !user.usage || shouldResetUsage(user) ?
+        {
+          llmExtractionsThisMonth: 0,
+          chatMessagesThisMonth: 0,
+          usageResetAt: now,
+        }
+      : user.usage;
 
     await ctx.db.patch(userId, {
       usage: {
@@ -63,5 +93,28 @@ export const incrementChatUsage = internalMutation({
         chatMessagesThisMonth: currentUsage.chatMessagesThisMonth + 1,
       },
     });
+  },
+});
+
+export const resetStaleUsageCounters = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const users = await ctx.db.query('users').collect();
+    let resetCount = 0;
+
+    for (const user of users) {
+      if (!user.usage || !shouldResetUsage(user)) continue;
+
+      await ctx.db.patch(user._id, {
+        usage: {
+          llmExtractionsThisMonth: 0,
+          chatMessagesThisMonth: 0,
+          usageResetAt: Date.now(),
+        },
+      });
+      resetCount++;
+    }
+
+    return { resetCount };
   },
 });


### PR DESCRIPTION
## Summary
- Treat stale usage windows as reset when checking extraction/chat limits.
- Reset stale counters before incrementing usage so monthly rollovers persist.
- Add internal mutation to reset stale persisted usage counters in bulk.
- Schedule daily cron to run stale usage reset mutation.
- Add usage regression tests for stale checks, increments, and scheduled reset behavior.

## Files
- convex/usage.ts
- convex/crons.ts
- convex/__tests__/usage.test.ts

## Closes
- Closes #53